### PR TITLE
Dismissing notification when dismissed and onClose prop is passed in

### DIFF
--- a/docs/js/components/NotificationComponents.react.js
+++ b/docs/js/components/NotificationComponents.react.js
@@ -110,6 +110,21 @@ class Notifications extends React.Component {
             </pre>
           </div>
         </div>
+
+        <h3>Dismissable with callback</h3>
+
+        <div className="category row">
+          <div className="col-md-6">
+            <Toolkit.Notification classes='info' title="Title" onClose={function() {alert('called on dismiss')}}>Content</Toolkit.Notification>
+          </div>
+          <div className="col-md-6">
+            <pre>
+              <code className="jsx">
+                {"<Toolkit.Notification classes='info' title='Title' onClose={function() {alert('called on dismiss')}}>Content</Toolkit.Notification>"}
+              </code>
+            </pre>
+          </div>
+        </div>
       </section>
     )
   }

--- a/src/components/Notification/Notification.react.js
+++ b/src/components/Notification/Notification.react.js
@@ -15,8 +15,9 @@ class Notification extends React.Component {
 
   _handleClose() {
     if (this.props.onClose) {
-      return this.props.onClose();
+      this.props.onClose();
     }
+
     this.setState({
       showNotification: !this.state.showNotification
     });

--- a/src/components/Notification/Notification.spec.js
+++ b/src/components/Notification/Notification.spec.js
@@ -50,11 +50,11 @@ describe('Notification component', () => {
 
   it('should call onClose prop if passed in when dismissable', () => {
     const spy = sinon.spy();
-    const renderedComponent = shallow(<NowNotification onClose={spy}>Content</NowNotification>)
-    
-    renderedComponent.instance()._handleClose(); 
+    const renderedComponent = shallow(<NowNotification onClose={spy}>Content</NowNotification>);
 
-    expect(spy.called).to.eq(true); 
+    renderedComponent.instance()._handleClose();
+
+    expect(spy.called).to.eq(true);
     expect(renderedComponent.state('showNotification')).to.eq(false);
   });
 

--- a/src/components/Notification/Notification.spec.js
+++ b/src/components/Notification/Notification.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
+import sinon from 'sinon';
 
 import NowNotification from './Notification.react';
 
@@ -45,6 +46,16 @@ describe('Notification component', () => {
     renderedComponent.update();
 
     assert.equal(renderedComponent.find('.now-notification').length, 0);
+  });
+
+  it('should call onClose prop if passed in when dismissable', () => {
+    const spy = sinon.spy();
+    const renderedComponent = shallow(<NowNotification onClose={spy}>Content</NowNotification>)
+    
+    renderedComponent.instance()._handleClose(); 
+
+    expect(spy.called).to.eq(true); 
+    expect(renderedComponent.state('showNotification')).to.eq(false);
   });
 
   it('should not has a close icon if not dismissable', () => {


### PR DESCRIPTION
This fixes #63 

When passing in an onClose prop to the notifications it used to just call that when "x" was clicked and not actually dismiss the notification.