### PR TITLE
removing npmrc because the styleguide is now public

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ If you're running an ES6 project and wish to only import specific components tha
 npm install @nowtv/nowtv-react-toolkit --save
 ```
 
-**Note: When installing onto external services such as heroku, you will need to ensure that the app has correct NPM scope access using an NPM_TOKEN env variable.**
-
 2. Use the @nowtv/nowtv-styleguide css
 
 E.g.

--- a/app.json
+++ b/app.json
@@ -8,9 +8,6 @@
     },
     "NPM_CONFIG_PRODUCTION": {
       "required": true
-    },
-    "NPM_TOKEN" : {
-      "required": true
     }
   },
   "addons": [


### PR DESCRIPTION
Now that the styleguide is public we don't need a npm token to npm install.

So I've removed it, this should make it easier to develop externally too.